### PR TITLE
Added Components moduleId

### DIFF
--- a/src/toast.component.ts
+++ b/src/toast.component.ts
@@ -10,6 +10,7 @@ import {ToastData} from './toasty.service';
  * A Toast component shows message with title and close button.
  */
 @Component({
+  moduleId: module.id,
   selector: 'ng2-toast',
   directives: [CORE_DIRECTIVES],
   template: `

--- a/src/toasty.component.ts
+++ b/src/toasty.component.ts
@@ -13,6 +13,7 @@ import {ToastComponent} from './toast.component';
  * Toasty is container for Toast components
  */
 @Component({
+  moduleId: module.id,
   selector: 'ng2-toasty',
   directives: [CORE_DIRECTIVES, ToastComponent],
   template: `


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
  ng2-toasty doesn't work with prod build on angular-cli > RC5
  `ng build --prod`

Every Component needs an moduleId in order to work with prod build.
