### PR TITLE
feat(html-content): generic template

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ export * from './src/toasty.component';
 
 import { ToastyComponent } from './src/toasty.component';
 import { ToastComponent } from './src/toast.component';
+import { ToastyTemplate, ToastyTemplateWrapper } from './src/shared';
 import { ToastyService, ToastyConfig, toastyServiceFactory } from './src/toasty.service';
 
 export let providers = [
@@ -19,8 +20,8 @@ export let providers = [
 
 @NgModule({
     imports: [CommonModule],
-    declarations: [ToastComponent, ToastyComponent],
-    exports: [ ToastComponent, ToastyComponent],
+    declarations: [ToastComponent, ToastyComponent, ToastyTemplate, ToastyTemplateWrapper],
+    exports: [ ToastComponent, ToastyComponent, ToastyTemplate],
     providers: providers
 })
 export class ToastyModule {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,35 @@
+import { Directive, TemplateRef, OnInit, Input, ViewContainerRef } from '@angular/core';
+
+@Directive({
+    selector: '[toastyTemplate]'
+})
+export class ToastyTemplate {
+
+    @Input('toastyTemplate') type: string;
+
+    constructor(public templateRef: TemplateRef<any>) {
+    }
+
+    public getType(): string {
+        return this.type;
+    }
+}
+
+@Directive({
+    selector: '[toastyTemplateWrapper]'
+})
+export class ToastyTemplateWrapper implements OnInit {
+
+    @Input() context: any;
+
+    @Input('toastyTemplateWrapper') templateRef: TemplateRef<any>;
+
+    constructor(public viewContainer: ViewContainerRef) {
+    }
+
+    ngOnInit(): void {
+        this.viewContainer.createEmbeddedView(this.templateRef, {
+            '\$implicit': this.context
+        });
+    }
+}

--- a/src/toast.component.ts
+++ b/src/toast.component.ts
@@ -1,9 +1,7 @@
 // Copyright (C) 2016 Sergey Akopkokhyants
 // This project is licensed under the terms of the MIT license.
 // https://github.com/akserg/ng2-toasty
-
-import { Component, Input, Output, EventEmitter } from '@angular/core';
-
+import { Component, Input, Output, EventEmitter, TemplateRef } from '@angular/core';
 import { ToastData } from './toasty.service';
 
 /**
@@ -15,9 +13,15 @@ import { ToastData } from './toasty.service';
         <div class="toast" [ngClass]="[toast.type, toast.theme]">
             <div *ngIf="toast.showClose" class="close-button" (click)="close($event)"></div>
             <div *ngIf="toast.title || toast.msg" class="toast-text">
-                <span *ngIf="toast.title" class="toast-title">{{toast.title}}</span>
+                <span *ngIf="toast.title" class="toast-title">
+                    <span *ngIf="!titleTemplate">{{toast.title}}</span>
+                    <template *ngIf="titleTemplate" [toastyTemplateWrapper]="titleTemplate" [context]="toast"></template>
+                </span>
                 <br *ngIf="toast.title && toast.msg" />
-                <span *ngIf="toast.msg" class="toast-msg">{{toast.msg}}</span>
+                <span *ngIf="toast.msg" class="toast-msg">
+                    <span *ngIf="!messageTemplate">{{toast.msg}}</span>
+                    <template *ngIf="messageTemplate" [toastyTemplateWrapper]="messageTemplate" [context]="toast"></template>
+                </span>
             </div>
         </div>`
 })
@@ -25,6 +29,8 @@ export class ToastComponent {
 
   @Input() toast: ToastData;
   @Output('closeToast') closeToastEvent = new EventEmitter();
+  @Input() titleTemplate: TemplateRef<any>;
+  @Input() messageTemplate: TemplateRef<any>;
 
   /**
    * Event handler invokes when user clicks on close button.

--- a/src/toasty.component.ts
+++ b/src/toasty.component.ts
@@ -2,10 +2,11 @@
 // This project is licensed under the terms of the MIT license.
 // https://github.com/akserg/ng2-toasty
 
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, TemplateRef, QueryList, ContentChildren, AfterContentInit } from '@angular/core';
 
 import { isFunction } from './toasty.utils';
 import { ToastyService, ToastData, ToastyConfig } from './toasty.service';
+import { ToastyTemplate } from './shared';
 
 /**
  * Toasty is container for Toast components
@@ -14,14 +15,20 @@ import { ToastyService, ToastData, ToastyConfig } from './toasty.service';
   selector: 'ng2-toasty',
   template: `
     <div id="toasty" [ngClass]="[position]">
-        <ng2-toast *ngFor="let toast of toasts" [toast]="toast" (closeToast)="closeToast(toast)"></ng2-toast>
+        <ng2-toast *ngFor="let toast of toasts" [toast]="toast" [messageTemplate]="messageTemplate" [titleTemplate]="titleTemplate" (closeToast)="closeToast(toast)"></ng2-toast>
     </div>`
 })
-export class ToastyComponent implements OnInit {
+export class ToastyComponent implements OnInit, AfterContentInit {
   /**
    * Set of constants defins position of Toasty on the page.
    */
   static POSITIONS: Array<String> = ['bottom-right', 'bottom-left', 'top-right', 'top-left', 'top-center', 'bottom-center', 'center-center'];
+
+  @ContentChildren(ToastyTemplate)
+  private toastyTemplates: QueryList<any>;
+
+  public titleTemplate: TemplateRef<any>;
+  public messageTemplate: TemplateRef<any>;
 
   private _position: string = '';
   // The window position where the toast pops up. Possible values:
@@ -93,6 +100,28 @@ export class ToastyComponent implements OnInit {
             // Lets clear all toasts
             this.clearAll();
         }
+    });
+  }
+
+  /**
+   * `ngAfterContentInit` is called after a component's content has been fully initialized.
+   * We initialize `title` or `message` templates for the toast
+   */
+  ngAfterContentInit(): void {
+    this.toastyTemplates.forEach((toastyTemplate) => {
+      switch(toastyTemplate.getType()) {
+        case 'title':
+          this.titleTemplate = toastyTemplate.templateRef;
+          break;
+
+        case 'message':
+          this.messageTemplate = toastyTemplate.templateRef;
+          break;
+
+        default:
+          this.messageTemplate = toastyTemplate.templateRef;
+          break;
+      }
     });
   }
 

--- a/tests/toast.component.spec.ts
+++ b/tests/toast.component.spec.ts
@@ -3,6 +3,7 @@ import { TestBed, ComponentFixture }
 
 import {ToastData} from '../src/toasty.service';
 import {ToastComponent} from '../src/toast.component';
+import {ToastyTemplate, ToastyTemplateWrapper} from '../src/shared';
 
 describe('ToastComponent', () => {
 
@@ -23,7 +24,7 @@ describe('ToastComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [ToastComponent]
+            declarations: [ToastComponent, ToastyTemplate, ToastyTemplateWrapper]
         });
         TestBed.compileComponents();
     });
@@ -64,10 +65,10 @@ describe('ToastComponent', () => {
         componentFixture.detectChanges();
         expect(element.querySelector('.toast-text')).not.toBeNull();
 
-        expect(element.querySelector('.toast-title')).not.toBeNull();
-        expect(element.querySelector('.toast-title').innerHTML).toBe('title');
+        expect(element.querySelector('.toast-title span')).not.toBeNull();
+        expect(element.querySelector('.toast-title span').innerHTML).toBe('title');
 
-        expect(element.querySelector('.toast-msg')).toBeNull();
+        expect(element.querySelector('.toast-msg span')).toBeNull();
 
         componentFixture.componentInstance.toast.title = null;
         componentFixture.componentInstance.toast.msg = null;
@@ -81,10 +82,10 @@ describe('ToastComponent', () => {
         componentFixture.detectChanges();
         expect(element.querySelector('.toast-text')).not.toBeNull();
 
-        expect(element.querySelector('.toast-title')).toBeNull();
+        expect(element.querySelector('.toast-title span')).toBeNull();
 
-        expect(element.querySelector('.toast-msg')).not.toBeNull();
-        expect(element.querySelector('.toast-msg').innerHTML).toBe('msg');
+        expect(element.querySelector('.toast-msg span')).not.toBeNull();
+        expect(element.querySelector('.toast-msg span').innerHTML).toBe('msg');
 
         componentFixture.componentInstance.toast.title = null;
         componentFixture.componentInstance.toast.msg = null;
@@ -99,11 +100,11 @@ describe('ToastComponent', () => {
         componentFixture.detectChanges();
         expect(element.querySelector('.toast-text')).not.toBeNull();
 
-        expect(element.querySelector('.toast-title')).not.toBeNull();
-        expect(element.querySelector('.toast-title').innerHTML).toBe('title');
+        expect(element.querySelector('.toast-title span')).not.toBeNull();
+        expect(element.querySelector('.toast-title span').innerHTML).toBe('title');
 
-        expect(element.querySelector('.toast-msg')).not.toBeNull();
-        expect(element.querySelector('.toast-msg').innerHTML).toBe('msg');
+        expect(element.querySelector('.toast-msg span')).not.toBeNull();
+        expect(element.querySelector('.toast-msg span').innerHTML).toBe('msg');
 
         componentFixture.componentInstance.toast.title = null;
         componentFixture.componentInstance.toast.msg = null;

--- a/tests/toasty.component.spec.ts
+++ b/tests/toasty.component.spec.ts
@@ -4,6 +4,7 @@ import { TestBed, ComponentFixture }
 import {ToastyService, ToastData, ToastyConfig} from '../src/toasty.service';
 import {ToastyComponent} from '../src/toasty.component';
 import {ToastComponent} from '../src/toast.component';
+import {ToastyTemplate, ToastyTemplateWrapper} from '../src/shared';
 
 describe('ToastyComponent', () => {
 
@@ -37,7 +38,7 @@ describe('ToastyComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [ToastComponent, ToastyComponent],
+            declarations: [ToastComponent, ToastyComponent, ToastyTemplate, ToastyTemplateWrapper],
             providers: [ToastyService, ToastyConfig]
         });
         TestBed.compileComponents();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "index.ts",
+    "./src/shared.ts",
     "./src/toast.component.ts",
     "./src/toasty.component.ts",
     "./src/toasty.service.ts",


### PR DESCRIPTION
Alternative for PR [#64](https://github.com/akserg/ng2-toasty/pull/64)

* **What kind of change does this PR introduce?**
Close: https://github.com/akserg/ng2-toasty/issues/3



* **What is the current behavior?** (You can also link to an open issue here)
Not supporting 'html' content in toasts


* **What is the new behavior (if this is a feature change)?**
Supporting ability to projecting 'html' templates in toasts


* **Other information**:
Testings using this branch:
[ng2-webpack-demo/toasty-html-content](https://github.com/gilhanan/ng2-webpack-demo/tree/toasty-html-content)

Using that code:
``` html
<ng2-toasty>
  <template toastyTemplate="title" let-toast>
    HTML title: <span style="background-color: #1EAEDB; color: #E1CB00;">{{toast.title}}</span>
  </template>
  <template toastyTemplate="message" let-toast>
    HTML message: <span style="background-color: #ff0039; color: #00e104;">{{toast.msg}}</span>
  </template>
</ng2-toasty>
```

Gives the result:
![toasty-html-content-demo](https://cloud.githubusercontent.com/assets/5566282/23669326/65ef6ad8-036c-11e7-8409-eb99c4b5693c.png)

I would happy to review and discussing