### PR TITLE
feat(html-content): innerHTML property

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ export * from './src/toasty.component';
 
 import { ToastyComponent } from './src/toasty.component';
 import { ToastComponent } from './src/toast.component';
+import { SafeHtmlPipe } from './src/shared';
 import { ToastyService, ToastyConfig, toastyServiceFactory } from './src/toasty.service';
 
 export let providers = [
@@ -19,7 +20,7 @@ export let providers = [
 
 @NgModule({
     imports: [CommonModule],
-    declarations: [ToastComponent, ToastyComponent],
+    declarations: [ToastComponent, ToastyComponent, SafeHtmlPipe],
     exports: [ ToastComponent, ToastyComponent],
     providers: providers
 })

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,11 @@
+import { DomSanitizer } from '@angular/platform-browser';
+import { PipeTransform, Pipe } from '@angular/core';
+
+@Pipe({ name: 'safeHtml'})
+export class SafeHtmlPipe implements PipeTransform  {
+    constructor(private domSanitized: DomSanitizer) {}
+
+    transform(value: any, ...args: any[]): any {
+        return this.domSanitized.bypassSecurityTrustHtml(value);
+    }
+}

--- a/src/toast.component.ts
+++ b/src/toast.component.ts
@@ -15,9 +15,9 @@ import { ToastData } from './toasty.service';
         <div class="toast" [ngClass]="[toast.type, toast.theme]">
             <div *ngIf="toast.showClose" class="close-button" (click)="close($event)"></div>
             <div *ngIf="toast.title || toast.msg" class="toast-text">
-                <span *ngIf="toast.title" class="toast-title">{{toast.title}}</span>
+                <span *ngIf="toast.title" class="toast-title" [innerHTML]="toast.title | safeHtml"></span>
                 <br *ngIf="toast.title && toast.msg" />
-                <span *ngIf="toast.msg" class="toast-msg">{{toast.msg}}</span>
+                <span *ngIf="toast.msg" class="toast-msg" [innerHtml]="toast.msg | safeHtml"></span>
             </div>
         </div>`
 })

--- a/tests/toast.component.spec.ts
+++ b/tests/toast.component.spec.ts
@@ -3,6 +3,7 @@ import { TestBed, ComponentFixture }
 
 import {ToastData} from '../src/toasty.service';
 import {ToastComponent} from '../src/toast.component';
+import {SafeHtmlPipe} from '../src/shared';
 
 describe('ToastComponent', () => {
 
@@ -23,7 +24,7 @@ describe('ToastComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [ToastComponent]
+            declarations: [ToastComponent, SafeHtmlPipe]
         });
         TestBed.compileComponents();
     });

--- a/tests/toasty.component.spec.ts
+++ b/tests/toasty.component.spec.ts
@@ -4,6 +4,7 @@ import { TestBed, ComponentFixture }
 import {ToastyService, ToastData, ToastyConfig} from '../src/toasty.service';
 import {ToastyComponent} from '../src/toasty.component';
 import {ToastComponent} from '../src/toast.component';
+import {SafeHtmlPipe} from '../src/shared';
 
 describe('ToastyComponent', () => {
 
@@ -37,7 +38,7 @@ describe('ToastyComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [ToastComponent, ToastyComponent],
+            declarations: [ToastComponent, ToastyComponent, SafeHtmlPipe],
             providers: [ToastyService, ToastyConfig]
         });
         TestBed.compileComponents();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "index.ts",
+    "./src/shared.ts",
     "./src/toast.component.ts",
     "./src/toasty.component.ts",
     "./src/toasty.service.ts",


### PR DESCRIPTION
Alternative for pull requests [#63](https://github.com/akserg/ng2-toasty/pull/63) and [#64](https://github.com/akserg/ng2-toasty/pull/64),
and admittedly this one is my favorite implementation.

* **What kind of change does this PR introduce?**
Close: https://github.com/akserg/ng2-toasty/issues/3



* **What is the current behavior?** (You can also link to an open issue here)
Not supporting 'html' content in toasts


* **What is the new behavior (if this is a feature change)?**
Supporting ability to projecting 'html' templates in toasts


* **Other information**:
Testings using this branch:
[ng2-webpack-demo/toasty-html-content](https://github.com/gilhanan/ng2-webpack-demo/tree/html-content-innerHTML)

Using that code:
``` html
options = {
 title: 'HTML title: <span style="background-color: #1EAEDB; color: #E1CB00;">Toast It!</span>',
 msg: 'HTML message: <span style="background-color: #FF0039; color: #00E104;">Mmmm, tasties...</span>'
};

this.toastyService.default(toastOptions);
```

Gives the result:
![toasty-html-content-demo](https://cloud.githubusercontent.com/assets/5566282/23669313/5c65a892-036c-11e7-87e2-88282a4d86a4.png)

I would happy to review and discussing